### PR TITLE
re-implement unsubscribe method

### DIFF
--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@stomp/stompjs": "^5.0.2",
+    "@stomp/stompjs": "^5.4.2",
     "sockjs-client": "^1.3.0"
   }
 }

--- a/packages/socket/src/types.ts
+++ b/packages/socket/src/types.ts
@@ -1,18 +1,26 @@
 import * as SockJS from 'sockjs-client';
 import * as Stomp from '@stomp/stompjs';
+
 export interface SocketServiceOptions {
     sockJS?: SockJS.Options;
 }
-export declare type SocketServiceMessageCallback = (message: Stomp.Message) => void;
+
+export type SocketServiceMessageCallback = (message: Stomp.Message) => void;
+
+export type SocketServiceSubscriptions = Map<string, Stomp.StompSubscription>;
+
 export declare class SocketService {
     client: Stomp.Client;
     connected?: boolean;
+    subscriptions: SocketServiceSubscriptions;
     private static readonly defaultOptions;
     private static readonly defaultHeaders;
     constructor(url: string, connectHeaders?: Stomp.StompHeaders, options?: SocketServiceOptions);
     subscribe(target: string, callback: SocketServiceMessageCallback): Stomp.StompSubscription;
+    unsubscribe(target: string): void;
     connect(): Promise<Stomp.Frame | undefined>;
     disconnect(): Promise<{}>;
     message(destination: string, body: string): void;
 }
+
 export default SocketService;


### PR DESCRIPTION
This PR re-implements the `unsubscribe` method we removed as part of version `3.0.0`. This is necessary because, at this time, the client we are using does not manage its own subscriptions internally.