### PR TITLE
updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # js-modules
 Statflo's JS public modules
 
+# Publishing
+
+1. cd to the directory corresponding with the package you are trying to publish
+2. run `npm version <new_version>`
+3. run `npm publish`
+4. if at any point you are prompted to login, statflo credentials can be found in Statflo's shared password manager
+
 # Credits
 Monorepo arch:
 https://github.com/Quramy/lerna-yarn-workspaces-example

--- a/packages/socket/README.md
+++ b/packages/socket/README.md
@@ -7,9 +7,9 @@ A promised StompJS and SockJS class for managing subscriptions easily.
 ```js
 import SocketService from '@statflo/socket';
 
-const service = new SocketService('http://foo.bar/live');
+const socket = new SocketService('http://foo.bar/live', { connectHeader: 'foobar' }); // where { connectHeader } is an instance of Stomp.StompHeaders
 
-service.connect({})  // where {} are Stomp headers
+service.connect()
     .then(frame => {
         console.log(frame);
     })
@@ -24,7 +24,7 @@ service.connect({})  // where {} are Stomp headers
 const exchange = service.subscribe('foo/bar', function(message) {
     console.log(message);
 });
-exchange.unsubscribe();
+exchange.unsubscribe('foo/bar');
 ```
 
 ### Messaging 


### PR DESCRIPTION
The docs for the socket have been out of date since we published version `3.0.0` of the module. This PR fixes that, and also adds some basic instructions for how we publish packages from this repo to NPM.