### PR TITLE
Added Polyfills

### DIFF
--- a/packages/socket/README.md
+++ b/packages/socket/README.md
@@ -7,7 +7,7 @@ A promised StompJS and SockJS class for managing subscriptions easily.
 ```js
 import SocketService from '@statflo/socket';
 
-const socket = new SocketService('http://foo.bar/live', { connectHeader: 'foobar' }); // where { connectHeader } is an instance of Stomp.StompHeaders
+const service = new SocketService('http://foo.bar/live', { connectHeader: 'foobar' }); // where { connectHeader } is an instance of Stomp.StompHeaders
 
 service.connect()
     .then(frame => {

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -31,6 +31,9 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^5.4.2",
-    "sockjs-client": "^1.3.0"
+    "es6-object-assign": "1.1.0",
+    "es6-promise": "4.2.8",
+    "sockjs-client": "^1.3.0",
+    "text-encoding": "0.7.0"
   }
 }

--- a/packages/socket/src/socket.ts
+++ b/packages/socket/src/socket.ts
@@ -1,3 +1,8 @@
+// polyfills
+import 'es6-promise/auto';
+import 'es6-object-assign/auto';
+import 'text-encoding';
+
 import * as SockJS from 'sockjs-client';
 import * as Stomp  from '@stomp/stompjs/esm5';
 import {


### PR DESCRIPTION
Turns out the Stomp JS library we are using needs certain polyfills in order to work in any Microsoft browser. Thankfully it's documented here: https://stomp-js.github.io/guide/stompjs/rx-stomp/ng2-stompjs/2018/06/29/pollyfils-for-stompjs-v5.html

I added the recommended dependencies `es6-object-assign` and `text-encoding` as well as a polyfill for promises for good measure.